### PR TITLE
Non-max suppression variable distance, with CLI option

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,6 +14,7 @@ var OutputFileName string
 var StdDev float64
 var UpperThreshold int
 var LowerThreshold int
+var NonMaxSuppressionDistance int
 
 // upper (u) and lower (l) for setting threshold values
 // no-blur option
@@ -28,7 +29,14 @@ CIC uses image processing and edge detection techniques to turn any image file
 into a colouring sheet.`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		cic.ConvertImageToColouring(args[0], OutputFileName, StdDev, UpperThreshold, LowerThreshold)
+		cic.ConvertImageToColouring(
+			args[0],
+			OutputFileName,
+			StdDev,
+			UpperThreshold,
+			LowerThreshold,
+			NonMaxSuppressionDistance,
+		)
 	},
 }
 
@@ -58,4 +66,6 @@ func init() {
 		"Upper threshold for edge suppression")
 	rootCmd.Flags().IntVarP(&LowerThreshold, "lower", "l", 10,
 		"Lower threshold for edge suppression")
+	rootCmd.Flags().IntVarP(&NonMaxSuppressionDistance, "distance", "d", 1,
+		"Interval for non-maximum suppression in pixels")
 }

--- a/imgproc/colourproc.go
+++ b/imgproc/colourproc.go
@@ -326,6 +326,7 @@ func RunSeparateColourImageProc() {
 	fmt.Print(" Done\n")
 }
 
+// [todo] -- add root app CLI options to colour processing
 func RunColourImageProc(filename string, outputFilename string) {
 	fmt.Print("Reading in file...")
 
@@ -357,7 +358,8 @@ func RunColourImageProc(filename string, outputFilename string) {
 	fmt.Print(" Done\n")
 
 	fmt.Print("Applying non-max suppression...")
-	ig = ig.NonmaxSuppression()
+	// [todo] - Replace function parameter with distance value
+	ig = ig.NonmaxSuppression(1)
 	fmt.Print(" Done\n")
 
 	fmt.Print("Applying threshold suppression...")


### PR DESCRIPTION
Allow specifying the interval/distance over which non-maximum suppression takes place. This reduces doubling of edge lines where a smooth edge gives rise to multiple edge pixels, of which every other one is selected when only a one-pixel interval is used. Using other small integer values seems to improve performance for images tested.

Also adds a command line option for selecting the interval distance, for the black and white case (colour implementation yet to be configured to use command line option parameter values)